### PR TITLE
Manually import Gdk before ulauncher imports

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,10 @@
 import json
 import logging
 from time import sleep
+
+import gi
+gi.require_version('Gdk', '3.0')
+
 from ulauncher.api.client.Extension import Extension
 from ulauncher.api.client.EventListener import EventListener
 from ulauncher.api.shared.event import KeywordQueryEvent, ItemEnterEvent


### PR DESCRIPTION
Fixes an issue on systems with Gdk 4.0 required (such as Gnome 40) that would cause the extension to exit instantly

Should resolve the issue until Ulauncher/Ulauncher#717 is merged